### PR TITLE
Add specific competency language to definition

### DIFF
--- a/open_org_definition.md
+++ b/open_org_definition.md
@@ -2,7 +2,7 @@
 
 ## Preamble
 
-Openness is becoming increasingly central to the ways groups and teams of all sizes are working together to achieve shared goals. And today, the most forward-thinking organizations—whatever their missions—are embracing openness as a necessary orientation toward success. They’ve seen that openness can lead to:
+Openness is becoming increasingly central to the ways groups and teams of all sizes are working together to achieve shared goals. And today, the most forward-thinking organizations—whatever their missions—are embracing openness as a necessary orientation toward success. They've seen that openness can lead to:
 
 * **Greater agility**, as members are more capable of working toward goals in unison and with shared vision;
 * **Faster innovation**, as ideas from both inside and outside the organization receive more equitable consideration and rapid experimentation, and;
@@ -22,7 +22,7 @@ While every organization is different—and therefore every example of an open o
 
 Open organizations take many shapes. Their sizes, compositions, and missions vary. But the following five characteristics are the hallmarks of any open organization.
 
-In practice, every open organization likely exemplifies each one of these characteristics differently, and to a greater or lesser extent. Moreover, some organizations that don’t consider themselves open organizations might nevertheless embrace a few of them. But truly open organizations embody them all—and they connect them in powerful and productive ways.
+In practice, every open organization likely exemplifies each one of these characteristics differently, and to a greater or lesser extent. Moreover, some organizations that don't consider themselves open organizations might nevertheless embrace a few of them. But truly open organizations embody them all—and they connect them in powerful and productive ways.
 
 That fact makes explaining any one of the characteristics difficult without reference to the others.
 
@@ -30,26 +30,93 @@ That fact makes explaining any one of the characteristics difficult without refe
 
 In open organizations, transparency reigns. As much as possible (and advisable) under applicable laws, open organizations work to make their data and other materials easily accessible to both internal and external participants; they are open for any member to review them when necessary (see also _inclusivity_). Decisions are transparent to the extent that everyone affected by them understands the processes and arguments that led to them; they are open to assessment (see also _collaboration_). Work is transparent to the extent that anyone can monitor and assess a project's progress throughout its development; it is open to observation and potential revision if necessary (see also _adaptability_).
 
+In open organizations, transaprency looks like:
+
+* Everyone working on a project or initiative has access to all pertinent materials by default.
+
+* People willingly disclose their work, invite participation on projects before those projects are complete and/or "final," and respond positively to request for additional details.
+
+* People affected by decisions can access and review the processes and arguments that lead to those decisions, and they can comment on and respond to them.
+
+* Leaders encourage others to tell stories about both their failures and their successes without fear of repercussion; associates are forthcoming about both.
+
+* People value both success and failures for the lessons they provide.
+
 ### Inclusivity
 
 Open organizations are inclusive. They not only welcome diverse points of view but also implement specific mechanisms for inviting multiple perspectives into dialog wherever and whenever possible. Interested parties and newcomers can begin assisting the organization without seeking express permission from each of its stakeholders (see also _collaboration_). Rules and protocols for participation are clear (see also _transparency_) and operate according to vetted and common standards.
+
+In open organizations, inclusivity looks like:
+
+* Technical channels and social norms for encouraging diverse points of view are well-established and obvious.
+
+* Protocols and procedures for participation are clear, widely available, and acknowledged, allowing for constructive inclusion of diverse perspectives.
+
+* The organization features multiple channels and/or methods for receiving feedback in order to accommodate people's preferences.
+
+* Leaders regularly assess and respond to feedback they receive, and cultivate a culture that encourages frequent dialog regarding this feedback.
+
+* Leaders are conscious of voices not present in dialog and actively seek to include or incorporate them.
+
+* People feel a duty to voice opinions on issues relevant to their work or about which they are passionate.
+
+* People work transparently and share materials via common standards and/or agreed-upon platforms that do not prevent others from accessing or modifying them.
 
 ### Adaptability
 
 Open organizations are flexible and resilient organizations. Organizational policies and technical apparatuses ensure that both positive and negative feedback loops have a genuine and material effect on organizational operation; participants can control and potentially alter the conditions under which they work. They report frequently and thoroughly on the outcomes of their endeavors (see also _transparency_) and suggest adjustments to collective action based on assessments of these outcomes. In this way, open organizations are fundamentally oriented toward continuous engagement and learning.
 
+In open organizations, adaptability looks like:
+
+* Feedback mechanisms are accessible both to members of the organization and to outside members, who can offer suggestions.
+
+* Feedback mechanisms allow and encourage peers to assist one another without managerial oversight, if necessary.
+
+* Leaders work to ensure that feedback loops genuinely and materially impact the ways people in the organization operate.
+
+* Processes for collective problem solving, collaborative decision making, and continuous learning are in place, and the organization rewards both personal and team learning to reinforce a growth mindset.
+
+* People tend to understand the context for the changes they're making or experiencing.
+
+* People are not afraid to make mistakes, yet projects and teams are comfortable adapting their pre-existing work to project-specific contexts in order to avoid repeated failures.
+
 ### Collaboration
 
 Work in an open organization involves multiple parties by default. Participants believe that joint work produces better (more effective, more sustainable) outcomes, and specifically seek to involve others in their efforts (see also _inclusivity_). Products of work in open organizations afford additional enhancement and revision, even by those not affiliated with the organization (see also, _adaptability_).
+
+In open organizations, collaboration looks like:
+
+
+* People tend to believe that working together produces better results.
+
+* People tend to begin work collaboratively, rather than "add collaboration" after they've each completed individual components of work.
+
+* People tend to engage partners outside their immediate teams when undertaking new projects.
+
+* Work produced collaboratively is easily available internally for others to build upon.
+
+* Work produced collaboratively is available externally for creators outside the organization to use in potentially unforeseen ways.
+
+* People can discover, provide feedback on, and join work in progress easily—and are welcomed to do so.
 
 ### Community
 
 Open organizations are communal. Shared values and purpose guide participation in open organizations, and these values—more so than arbitrary geographical locations or hierarchical positions—help determine the organization's boundaries and conditions of participation. Core values are clear, but also subject to continual revision and critique, and are instrumental in defining conditions for an organization's success or failure (see also _adaptability_).
 
+In open organizations, community looks like:
+
+* Shared values and principles that inform decision-making and assessment processes are clear and obvious to members.
+
+* People feel equipped and empowered to make meaningful contributions to collaborative work.
+
+* Leaders mentor others and demonstrate strong accountability to the group by modeling shared values and principles.
+
+* People have a common language and work together to ensure that ideas do not get "lost in translation," and they are comfortable sharing their knowledge and stories to further the group's work.
+
 ## Revision History
 
-Version 1.0  
-Updated December 2016  
+Version 2.0  
+Updated April 2017  
 The Open Organization Ambassadors at Opensource.com
 
 ## License

--- a/open_org_definition.md
+++ b/open_org_definition.md
@@ -42,6 +42,10 @@ In open organizations, transaprency looks like:
 
 * People value both success and failures for the lessons they provide.
 
+
+* Goals are public and explicit, and people working on projects clearly indicate roles and responsibilities to enhance accountability.
+
+
 ### Inclusivity
 
 Open organizations are inclusive. They not only welcome diverse points of view but also implement specific mechanisms for inviting multiple perspectives into dialog wherever and whenever possible. Interested parties and newcomers can begin assisting the organization without seeking express permission from each of its stakeholders (see also _collaboration_). Rules and protocols for participation are clear (see also _transparency_) and operate according to vetted and common standards.


### PR DESCRIPTION
The Open Organization Ambassadors have collaborated on an important extension and clarification of The Open Organization Definition, and their modifications are now available for public review. This update specifically adds "competency-oriented" language that specifies behaviors and attitudes typical in successful open organizations. That is to say: it more thoroughly describes what open _looks like_ in practice (see #7 for more details).

Community members should review this pull request carefully and register their reactions to, support for, or issues with the updated definition, which we will otherwise merge into the main branch by the end of the week.