### PR TITLE
Supplement the Open Organization Definition with a maturity model

### DIFF
--- a/open_org_maturity_model.md
+++ b/open_org_maturity_model.md
@@ -1,0 +1,137 @@
+# The Open Organization Maturity Model
+
+## Transparency
+
+### Level 1
+
+- Individuals and teams release project materials internally, after work is complete
+- People affected by decisions are often surprised to learn about those decisions
+- Materials that are part of decision-making practices are available for review when the decision is final
+- Individuals and teams are comfortable sharing stories of successes
+- Individuals and teams neither contribute to nor draw upon an organizational knowledge commons
+- Decision-makers often withhold data and resources without explanation
+
+### Level 2
+
+- Non-sensitive materials are accessible to all members of project teams
+- People recognize that leaders are making decisions that affect them
+- Materials that are part of decision-making practices are available at certain project milestones
+- Individuals and teams are comfortable sharing stories of successes and failures in retrospective fashion
+- A "read-only" knowledge commons exists
+- Decision-makers withhold data and resources and are clear about what they're not releasing—but not why they're not releasing it
+
+### Level 3
+
+- Non-sensitive materials are accessible to project team and organization at large (possibly outside the organization as well)
+- People feel like they know about—and are helping to shape—big decisions as those decisions are unfolding
+- Materials that are part of decision-making practices are available for review at the beginning of projects and easily accessible according to known standards
+- Individuals and teams are comfortable sharing stories of successes and failures, as well as having difficult conversations during project execution
+- A robust and easily-accessible knowledge commons exists, and teams make generous use of it
+Individuals and teams understand why certain sensitive materials are not available to them
+
+## Inclusivity
+
+### Level 1
+
+- Organization is working to establish guidelines and channels for encouraging diverse points of view by inviting opinions and participation from anyone who is interested in providing them.
+- Protocols and procedures for participating in organization-wide discussions are the result of collaborative efforts.
+- Leaders are open to receiving feedback and creating an environment where people feel safe providing it.
+- Leaders maintain at least one clear and direct channel for receiving feedback from others, who feel comfortable using it.
+- People share materials, but only when asked to, and typically via private channels or discussions.
+- Organization encourages leaders to be conscious of voices not present in dialog and to actively seek them out for inclusion.
+
+### Level 2
+
+- Guidelines for sharing and soliciting diverse points of view on company or departmental decisions and are published for anyone to see
+- People create materials on organizationally-sanctioned platforms that are accessible to others by default
+- Organization can demonstrate that protocols and procedures for participating in organization-wide discussions are the result of collaborative efforts between cross-functional groups that include representation from different functional and geographic teams
+- Leaders demonstrate willingness to address and respond to feedback they’ve received, typically in a way that entire teams can see
+- Leaders work to establish multiple channels and methods for feedback, and they encourage their use
+- Leaders routinely encourage all team members to participate in decision-making practices, and they expressly solicit such participation from parties that may be reluctant to do so
+
+### Level 3
+
+- Guidelines for sharing and soliciting diverse points of view on company or departmental decisions and are published for anyone to see, and an advisory council for maintaining these guidelines exists
+- The organization advances clear guidelines for participants' use of collaborative platforms, and encourages the use open technical standards in their work
+- Leaders establish multiple channels and methods for feedback, each of which is aligned with people’s preferences for providing it; leaders are reflexive about their attitudes toward feedback and open the feedback processes themselves to feedback from others
+- All members of the organization feel empowered and enabled to share opinions constructively on any matter relevant to their work or about which they feel passionate 
+- Leaders maintain team-facing or public-facing records of the feedback they’ve received and/or the actions they’ve taken to address this feedback
+- The organization assists leaders with specific resources (training programs, access to content, etc.) as they work to hone their strategies for forming inclusive teams
+
+## Adaptability
+
+### Level 1
+
+- Organization routinely solicits feedback from internal stakeholders.
+- Organization provides opportunities for members to learn about other aspects of the organization
+- Members feel like they understand the organization’s goals
+- Organization encourages participants to solve problems by working together
+- Failure is a frequent topic of discussion among team members
+
+### Level 2
+
+- Organization promotes an obvious and accessible method for gathering feedback from both internal stakeholders and external parties
+- Organization promotes continuous learning with structured programs and events
+- Leaders and participants regularly discuss their progress on projects, key metrics and performance indicators, and their roles in the organization’s goals and strategies
+- Organization promotes a structured process for collective decision-making, and members use it regularly
+- Members understand that failure is an acceptable outcome of experimentation
+
+### Level 3
+
+- Organization expressly allocates resources for collecting, managing, and acting on feedback from external parties and/or stakeholders
+- Organization provides clear, structured, process and/or platform members can use to locate collaborative efforts they can join to learn more about and/or participate in a particular organizational function
+- Leaders create environments where participants feel comfortable addressing challenges without managerial oversight
+- Organization’s decision-making processes are collectively modifiable, and members feel comfortable adjusting their operational behaviors in response to changing conditions
+- Leaders cultivate a spirit of experimentation by spotlighting productive failures across the organization
+
+## Collaboration
+
+### Level 1
+
+- Participants share work only after initiating it themselves
+- Cross-functional teams can be difficult to build and maintain
+- Members frequently work together on projects
+- Outcomes of collaboration remain within the team
+- Working groups and cross-functional teams often include the same faces and skill sets
+- Team revisits the outcomes of collaboration infrequently (or not at all)
+
+### Level 2
+
+- Participants initiate projects as a group
+- Cross-functional teams exist with little effort, but roles are often less clearly defined and governance is vague
+- Participants enjoy and prefer working together
+- Outcomes of collaboration are available to the entire organization
+- Groups are always seeking a diverse set of viewpoints, experiences, and skills
+- Outcomes of collaboration are the subject of future debate and revision
+
+### Level 3
+
+- Participants help other groups collaborate effectively
+- Cross-functional teams exist and roles/goals are posted publicly
+- Participants believe working together produces better outcomes
+- Outcomes of collaboration are available outside the organization
+- Groups effectively leverage members' diverse views and skills
+- Outcomes of collaboration see uptake, use, and/or modification outside the organization
+
+## Community
+
+### Level 1
+
+- Members of the group unite to define values and principles 
+- People feel welcome to participate in and contribute to the group; an open community aims to create psychological safe spaces, meaning that people are invited to share their thoughts and opinions within the community without fear of retribution
+- People understand that the best ideas win and leadership responsibilities emerge based on contribution and commitment; in an open community, leadership is not given; it is earned
+- A common language for the community emerges
+
+### Level 2
+
+- Documents expressing shared visions and agreements—like mission statements and [codes of conduct](http://todogroup.org/opencodeofconduct/)—are easily accessible and referenced often
+- Onboarding materials, personal inductions, and bonding give context to help community members understand how their contribution is needed
+- Leaders demonstrate dedication to shared values. They model the behavior their community has determined admirable and help resolve community problems
+- Culture comes to life through a common language. Community members make an effort to welcome new members and onboard them, taking time to explain jargon, acronyms, and inside jokes
+
+### Level 3
+
+- Shared values and principles inform decision-making, conflict resolution, and assessment processes.
+- People show shared consciousness and empowered execution. They feel agency and responsibility to the community.
+- Leaders understand that they grow by helping others grow and mentor more junior community members.
+- Mature open communities make an effort to collect and share stories of their community members to attract new members, grow their community, and provide mentorship


### PR DESCRIPTION
Following on from @semioticrobotic in #11:

> Thanks to some outstanding work by several ambassador working groups, we're now one step closer to realizing a potential outcome of [our conversation about "doing open."](https://github.com/open-organization-ambassadors/open-org-definition/issues/7#issue-203470858)
>
>We've recently completed a full draft of something we might call The Open Organization Maturity Model, a supplement to The Open Organization Definition aimed at helping teams and organizations better understand how they can advance their respective journeys toward greater and better openness.
>
>Let's take a look at the following language and determine if and how we want to turn it into a resource others can use in this way.